### PR TITLE
Change perform Interaction send INVALID _ID instead REJECTED

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/perform_interaction_request.h
@@ -207,7 +207,7 @@ class PerformInteractionRequest
    * same choice id returns false, otherwise returns
    * true.
    */
-  bool CheckChoiceIDFromRequest(
+  const mobile_apis::Result::eType CheckChoiceIDFromRequest(
       app_mngr::ApplicationSharedPtr app,
       const size_t choice_set_id_list_length,
       const smart_objects::SmartObject& choice_set_id_list) const;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/perform_interaction_request.cc
@@ -153,14 +153,13 @@ void PerformInteractionRequest::Run() {
     }
   }
 
-  if (!CheckChoiceIDFromRequest(
-          app,
-          choice_set_id_list_length,
-          msg_params[strings::interaction_choice_set_id_list])) {
+  const auto result = CheckChoiceIDFromRequest(
+    app, choice_set_id_list_length, msg_params[strings::interaction_choice_set_id_list]);
+  if (mobile_apis::Result::SUCCESS != result) {
     LOG4CXX_ERROR(logger_,
                   "PerformInteraction has choice sets with "
                   "duplicated IDs or application does not have choice sets");
-    SendResponse(false, mobile_apis::Result::INVALID_ID);
+    SendResponse(false, result);
     return;
   }
 
@@ -996,7 +995,7 @@ bool PerformInteractionRequest::CheckChoiceSetListVRCommands(
   return true;
 }
 
-bool PerformInteractionRequest::CheckChoiceIDFromRequest(
+const mobile_apis::Result::eType PerformInteractionRequest::CheckChoiceIDFromRequest(
     ApplicationSharedPtr app,
     const size_t choice_set_id_list_length,
     const smart_objects::SmartObject& choice_set_id_list) const {
@@ -1013,7 +1012,7 @@ bool PerformInteractionRequest::CheckChoiceIDFromRequest(
       LOG4CXX_ERROR(
           logger_,
           "Couldn't find choiceset_id = " << choice_set_id_list[i].asInt());
-      return false;
+      return mobile_apis::Result::REJECTED;
     }
 
     choice_list_length = (*choice_set)[strings::choice_set].length();
@@ -1027,11 +1026,11 @@ bool PerformInteractionRequest::CheckChoiceIDFromRequest(
                       "choice with ID "
                           << choices_list[k][strings::choice_id].asInt()
                           << " already exists");
-        return false;
+        return mobile_apis::Result::INVALID_ID;
       }
     }
   }
-  return true;
+  return mobile_apis::Result::SUCCESS;
 }
 
 const bool PerformInteractionRequest::HasHMIResponsesToWait() const {


### PR DESCRIPTION
Fixes #

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
ATF script provided at [PR](https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/2054)

### Summary
In case of processing DeleteInteractionChoiceSet HMI Perform Interaction send INVALID _ID instead REJECTED.
This commit corrected this behavior in PerformInteractionRequest::CheckChoiceIDFromRequest.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)